### PR TITLE
🔧 GitHub Actionsのフィルタリング条件とアクションバージョンの更新

### DIFF
--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -13,7 +13,8 @@ jobs:
   generate-pr-description:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: contains(github.event.pull_request.user.login, 'renovate') == false
+    # Check if the PR is not created by 'renovate' or 'tqer39-apps'
+    if: contains(fromJSON('["renovate[bot]", "tqer39-apps[bot]"]'), github.event.pull_request.user.login) == false
     permissions:
       pull-requests: write
     steps:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     if: contains(github.event.pull_request.user.login, 'renovate') == false
     steps:
       - uses: actions/checkout@v4
-      - uses: tqer39/generate-pr-description-action@v1.0.0
+      - uses: tqer39/openai-generate-pr-description@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           open-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    if: contains(github.event.pull_request.user.login, 'renovate') == false
+    if: contains(fromJSON('["renovate[bot]"]'), github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
       - uses: tqer39/openai-generate-pr-description@v1.0.1

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -31,7 +31,7 @@ jobs:
     if: contains(github.event.pull_request.user.login, 'renovate') == false
     steps:
       - uses: actions/checkout@v4
-      - uses: tqer39/generate-pr-description-action@v1.0.0
+      - uses: tqer39/openai-generate-pr-description@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           open-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.user.login, 'renovate') == false
+    if: contains(fromJSON('["renovate[bot]"]'), github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
       - uses: tqer39/openai-generate-pr-description@v1.0.1


### PR DESCRIPTION

## 📒 変更点の概要

- `README.md`および`docs/README.ja.md`のGitHub Actionsのフィルタリング条件を改善しました。
- `openai-generate-pr-description`アクションのバージョンを`v1.0.1`に更新しました。
- `.github/workflows/generate-pr-description.yml`において、PR作成者のフィルタリング条件を改善しました。

## ⚒ 技術的な詳細

- `README.md`と`docs/README.ja.md`のフィルタリング条件を、`contains(github.event.pull_request.user.login, 'renovate') == false`から`contains(fromJSON('["renovate[bot]"]'), github.event.pull_request.user.login) == false`に変更しました。これにより、`renovate[bot]`からのPRを正確にフィルタリングします。
- `.github/workflows/generate-pr-description.yml`では、`renovate`だけでなく`tqer39-apps`からのPRもフィルタリングするように条件を拡張しました。具体的には、`contains(fromJSON('["renovate[bot]", "tqer39-apps[bot]"]'), github.event.pull_request.user.login) == false`としました。
- `openai-generate-pr-description`アクションのバージョンを`v1.0.0`から`v1.0.1`に更新し、最新の機能と修正を取り入れました。

## ⚠ 注意点

- フィルタリング条件の変更により、特定のボットからのPRが意図せずに除外される可能性があります。必要に応じて条件を見直してください。