### PR TITLE
🔄 バージョンバンプとワークフロートリガの修正

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,20 +3,16 @@ name: Auto Merge
 on:
   pull_request:
     types: [labeled]
-  check_suite:
-    types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.check_suite.id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: >-
-      (github.event_name == 'pull_request' && github.event.label.name == 'claude-auto') ||
-      github.event_name == 'check_suite'
+    if: github.event.label.name == 'claude-auto'
     permissions:
       contents: read
       pull-requests: read
@@ -28,46 +24,20 @@ jobs:
           app-id: ${{ secrets.GHA_APP_ID }}
           private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
 
-      - name: PR 番号の取得
-        id: pr
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.check_suite.head_sha }}/pulls" \
-              --jq '.[0].number // empty')
-            echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: claude-auto ラベルの確認
-        if: steps.pr.outputs.number != ''
-        id: label-check
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          HAS_LABEL=$(gh pr view "${{ steps.pr.outputs.number }}" \
-            --repo "${{ github.repository }}" \
-            --json labels --jq '[.labels[].name] | any(. == "claude-auto")')
-          echo "has_label=${HAS_LABEL}" >> "$GITHUB_OUTPUT"
-
       - name: PR の approve
-        if: steps.pr.outputs.number != '' && steps.label-check.outputs.has_label == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr review "${{ steps.pr.outputs.number }}" \
+          gh pr review "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --approve \
             --body "GitHub App による自動承認（claude-auto ラベル検出）"
 
       - name: auto-merge の有効化（squash）
-        if: steps.pr.outputs.number != '' && steps.label-check.outputs.has_label == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr merge "${{ steps.pr.outputs.number }}" \
+          gh pr merge "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --squash \
             --auto

--- a/docs/superpowers/specs/2026-05-17-workflow-result-design.md
+++ b/docs/superpowers/specs/2026-05-17-workflow-result-design.md
@@ -158,4 +158,13 @@ permissions:
 | --- | --- |
 | ブランチ保護更新を忘れて PR 2 を出すと merge 不可 | 移行手順に明記、PR 2 の説明に手順チェックリストを含める |
 | 旧 3 ファイルを残したまま放置すると重複実行で API クォータ消費 | PR 2 を必ずセットで実施。PR 1 マージ後 24h 以内を目安 |
-| `auto-merge.yml` の `check_suite: completed` が `workflow-result` 完了を検知しない | check_suite はワークフロー単位で発火するため、`ci.yml` 完了で必ず発火する。動作確認は移行後に claude-auto ラベルで実施 |
+| `auto-merge.yml` の `check_suite: completed` が `workflow-result` 完了を検知しない | **当初想定が誤りだった**。GitHub の仕様により、GitHub Actions が作成した check_suite では `check_suite` イベントは発火しない（再帰防止）。実機でも発火実績ゼロ（Issue #348 で確認）。トリガから削除済み。`pull_request: labeled` のみで運用する |
+
+### 追記: `check_suite: completed` トリガの実機検証結果（Issue #348）
+
+- `gh run list --workflow=auto-merge.yml --event=check_suite` の結果は常に空
+- GitHub Actions 公式ドキュメントに以下の記述あり:
+  > To prevent recursive workflows, this event does not trigger workflows if the check suite was created by GitHub Actions or if the check suite's head SHA is associated with GitHub Actions.
+- すなわち `workflow-result` ジョブ完了に伴う check_suite は GitHub Actions 由来のため、`check_suite: completed` トリガは構造上発火し得ない
+- 「claude-auto ラベルを CI 完了後に後付け」シナリオも、`pull_request: labeled` で発火するため `check_suite` 経路は不要
+- 結論: `auto-merge.yml` から `check_suite` トリガを削除し、`pull_request: labeled` 単独運用に整理

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "generate-pr-description-action"
-version = "2.0.4"
+version = "2.0.5"
 description = "Generate PR title and description using OpenRouter API"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "generate-pr-description-action"
-version = "2.0.3"
+version = "2.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION

## 📒 Summary of Changes

- 🔼 `pyproject.toml` のバージョンを `2.0.4` から `2.0.5` にバンプ。
- 🛠️ `.github/workflows/auto-merge.yml` から `check_suite` トリガを削除し、`pull_request: labeled` のみで運用。

## ⚒ Technical Details

- 📄 `pyproject.toml` と `uv.lock` のバージョン情報を更新。
- 🗑️ `auto-merge.yml` から `check_suite: completed` トリガを削除し、`pull_request` イベントに依存するように変更。
- 🔍 `check_suite` トリガが GitHub Actions 由来の `check_suite` では発火しないことを確認し、ドキュメントに基づいて修正。

## ⚠ Points of Caution

- ⚠️ `check_suite` トリガが削除されたため、`pull_request: labeled` イベントが正しく設定されていることを確認してください。