### PR TITLE
🧪 test: workflow-result が generate-pr-description 失敗時に warning で通ることを検証 (refs #349)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          api-key: 'dummy-invalid-key-for-issue-349-test'
           model: 'openai/gpt-4o'
           locale: 'ja'
 


### PR DESCRIPTION
## 目的

Issue #349 の確認項目を実機で検証するための **検証専用 PR**（マージしない）。

`generate-pr-description` を意図的に失敗させ、`workflow-result` ジョブが `::warning::` を出しつつ `success` で完了することを確認する。

## 変更内容

- `.github/workflows/ci.yml` の `api-key` をダミー文字列に上書き

## 確認したいこと

- [ ] `CI / generate-pr-description` が `failure` になる
- [ ] `CI / workflow-result` が `success` で完了する
- [ ] `workflow-result` のログに `::warning::generate-pr-description failed (non-blocking)` が出る
- [ ] PR が（仕組み上）マージ可能な状態になる

## 後処理

確認後、PR は **クローズ（マージしない）** し、ブランチ・worktree を削除する。

Refs: #349